### PR TITLE
remove `--save` from installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Read up here for getting started and understanding the payment flow with Razorpa
 ## Installation
 
 ```bash
-npm i razorpay --save
+npm i razorpay
 ```
 
 ## Documentation


### PR DESCRIPTION
Purpose: 

-  fix command used for installation 

Explanation:

-  `--save` argument doesn't exist in recent npm versions anymore, it's the default behavior
-  This is the behavior as of npm 5
-  see: https://docs.npmjs.com/cli/install to check that `--save` doesn't exist
-  also see: https://stackoverflow.com/a/19578808/1311745 for verification