### PR TITLE
Adds support for partner auth

### DIFF
--- a/dist/api.js
+++ b/dist/api.js
@@ -7,6 +7,33 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 var request = require('request-promise');
 var nodeify = require('./utils/nodeify');
 
+var _require = require('./utils/razorpay-utils'),
+    isNonNullObject = _require.isNonNullObject;
+
+var allowedHeaders = {
+  "X-Razorpay-Account": ""
+};
+
+function getValidHeaders(headers) {
+
+  var result = {};
+
+  if (!isNonNullObject(headers)) {
+
+    return result;
+  }
+
+  return Object.keys(headers).reduce(function (result, headerName) {
+
+    if (allowedHeaders.hasOwnProperty(headerName)) {
+
+      result[headerName] = headers[headerName];
+    }
+
+    return result;
+  }, result);
+}
+
 function normalizeError(err) {
   throw {
     statusCode: err.statusCode,
@@ -25,9 +52,7 @@ var API = function () {
         user: options.key_id,
         pass: options.key_secret
       },
-      headers: {
-        'User-Agent': options.ua
-      }
+      headers: Object.assign({ 'User-Agent': options.ua }, getValidHeaders(options.headers))
     });
   }
 

--- a/dist/razorpay.js
+++ b/dist/razorpay.js
@@ -25,7 +25,8 @@ var Razorpay = function () {
     _classCallCheck(this, Razorpay);
 
     var key_id = options.key_id,
-        key_secret = options.key_secret;
+        key_secret = options.key_secret,
+        headers = options.headers;
 
 
     if (!key_id) {
@@ -43,7 +44,8 @@ var Razorpay = function () {
       hostUrl: 'https://api.razorpay.com/v1/',
       ua: 'razorpay-node@' + Razorpay.VERSION,
       key_id: key_id,
-      key_secret: key_secret
+      key_secret: key_secret,
+      headers: headers
     });
     this.addResources();
   }

--- a/dist/utils/razorpay-utils.js
+++ b/dist/utils/razorpay-utils.js
@@ -14,6 +14,10 @@ function isNumber(num) {
   return !isNaN(Number(num));
 }
 
+function isNonNullObject(input) {
+  return !!input && (typeof input === "undefined" ? "undefined" : _typeof(input)) === "object" && !Array.isArray(input);
+}
+
 function normalizeBoolean(bool) {
   if (bool === undefined) {
     return bool;
@@ -96,6 +100,7 @@ module.exports = {
   getDateInSecs: getDateInSecs,
   prettify: prettify,
   isDefined: isDefined,
+  isNonNullObject: isNonNullObject,
   getTestError: getTestError,
   validateWebhookSignature: validateWebhookSignature
 };

--- a/lib/api.js
+++ b/lib/api.js
@@ -2,6 +2,33 @@
 
 const request = require('request-promise')
 const nodeify = require('./utils/nodeify')
+const {
+  isNonNullObject
+} = require('./utils/razorpay-utils');
+
+const allowedHeaders = {
+  "X-Razorpay-Account": ""
+};
+
+function getValidHeaders (headers) {
+
+  const result = {};
+
+  if (!isNonNullObject(headers)) {
+
+    return result;
+  }
+
+  return Object.keys(headers).reduce(function (result, headerName) {
+
+    if (allowedHeaders.hasOwnProperty(headerName)) {
+
+      result[headerName] = headers[headerName];
+    }
+
+    return result;
+  }, result);
+}
 
 function normalizeError(err) {
   throw {
@@ -19,9 +46,10 @@ class API {
         user: options.key_id,
         pass: options.key_secret
       },
-      headers: {
-        'User-Agent': options.ua
-      }
+      headers: Object.assign(
+        {'User-Agent': options.ua},
+        getValidHeaders(options.headers)
+      )
     })
   }
 

--- a/lib/razorpay.js
+++ b/lib/razorpay.js
@@ -15,7 +15,7 @@ class Razorpay {
   }
 
   constructor(options = {}) {
-    let { key_id, key_secret } = options
+    let { key_id, key_secret, headers } = options
 
     if (!key_id) {
       throw new Error('`key_id` is mandatory')
@@ -32,7 +32,8 @@ class Razorpay {
       hostUrl: 'https://api.razorpay.com/v1/',
       ua: `razorpay-node@${Razorpay.VERSION}`,
       key_id,
-      key_secret
+      key_secret,
+      headers
     })
     this.addResources()
   }

--- a/lib/utils/razorpay-utils.js
+++ b/lib/utils/razorpay-utils.js
@@ -10,6 +10,12 @@ function isNumber(num) {
   return !isNaN(Number(num))
 }
 
+function isNonNullObject(input) {
+  return !!input &&
+         typeof input === "object" &&
+         !Array.isArray(input);
+}
+
 function normalizeBoolean(bool) {
   if (bool === undefined) {
     return bool
@@ -102,6 +108,7 @@ module.exports = {
   getDateInSecs,
   prettify,
   isDefined,
+  isNonNullObject,
   getTestError,
   validateWebhookSignature
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "razorpay",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "razorpay",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Official Node SDK for Razorpay API",
   "main": "dist/razorpay",
   "typings": "dist/razorpay",


### PR DESCRIPTION
Tests:
```
x = require(".");

// Normal access
r = new x({key_id: 'rzp_live_OPGrc7b83bKefz', key_secret: 'qdKFYGsul50Jggi8EtgI9E5K'})
r.orders.all().catch(console.error).then(console.log)

// Access using partner account
r = new x({key_id: 'rzp_test_partner_AosrEcUfxxWfKa', key_secret: 'VNT1v9mt6k5vZT4HBZ6rSs3n', headers: {"X-Razorpay-Account": "acc_AotEHYjTBWwPhy"}});
r.orders.all().catch(console.error).then(console.log)
```