### PR TITLE
add recipient_settlement_id parameter for transfers.all

### DIFF
--- a/dist/resources/transfers.js
+++ b/dist/resources/transfers.js
@@ -16,7 +16,8 @@ module.exports = function (api) {
           to = params.to,
           count = params.count,
           skip = params.skip,
-          payment_id = params.payment_id;
+          payment_id = params.payment_id,
+          recipient_settlement_id = params.recipient_settlement_id;
 
       var url = '/transfers';
 
@@ -41,7 +42,8 @@ module.exports = function (api) {
           from: from,
           to: to,
           count: count,
-          skip: skip
+          skip: skip,
+          recipient_settlement_id: recipient_settlement_id
         }
       }, callback);
     },

--- a/lib/resources/transfers.js
+++ b/lib/resources/transfers.js
@@ -5,7 +5,7 @@ const { normalizeDate, normalizeBoolean, normalizeNotes } = require('../utils/ra
 module.exports = function (api) {
   return {
     all(params = {}, callback) {
-      let { from, to, count, skip, payment_id } = params
+      let { from, to, count, skip, payment_id, recipient_settlement_id } = params
       let url = '/transfers'
 
       if (payment_id) {
@@ -29,7 +29,8 @@ module.exports = function (api) {
           from,
           to,
           count,
-          skip
+          skip,
+          recipient_settlement_id,
         }
       }, callback)
     },
@@ -91,3 +92,4 @@ module.exports = function (api) {
     },
   }
 }
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1375,12 +1375,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1395,17 +1397,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1522,7 +1527,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1534,6 +1540,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1548,6 +1555,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1555,12 +1563,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1579,6 +1589,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1659,7 +1670,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1671,6 +1683,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1792,6 +1805,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
`recipient_settlement_id` is allowed according to: https://razorpay.com/docs/route/api-reference/#fetch-transfers-for-a-settlement-id