### PR TITLE
fix: receipt is an optional param when creating orders

### DIFF
--- a/lib/resources/orders.js
+++ b/lib/resources/orders.js
@@ -51,10 +51,6 @@ module.exports = function (api) {
         throw new Error('`amount` is mandatory')
       }
 
-      if (!receipt) {
-        throw new Error('`receipt` is mandatory')
-      }
-
       let data = Object.assign({
         amount,
         currency,

--- a/test/resources/orders.spec.js
+++ b/test/resources/orders.spec.js
@@ -115,18 +115,6 @@ describe('ORDERS', () => {
           'Should throw exception when amount is not provided with emandate method'
         )
       }
-
-      try {
-        rzpInstance.orders.create({
-          amount: 100
-        })
-      } catch (e) {
-        assert.equal(
-          e.message,
-          '`receipt` is mandatory',
-          'Should throw exception when receipt is not provided'
-        )
-      }
     })
 
     it('Order create request', (done) => {


### PR DESCRIPTION
-refs: https://razorpay.com/docs/api/orders/#create-an-order

I have updated the test spec file.

You should build and publish this change asap, it is not a breaking change but an important one. On a side note, this library should be maintained regularly.


