### PR TITLE
Throw errors correctly and fix warning

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -31,10 +31,10 @@ function getValidHeaders (headers) {
 }
 
 function normalizeError(err) {
-  throw {
+  throw new Error ({
     statusCode: err.statusCode,
     error: err.error.error
-  }
+  })
 }
 
 class API {


### PR DESCRIPTION
Right now, every time there is an error, Node prints a warning saying `Warning: a promise was rejected with a non-error`. Rejecting a promise with a non-error which is being done right now makes debugging extremely hard.

This PR fixes that by correctly throwing an `Error` instead of a value that is not an `Error`. Due to this, the warning doesn't appear anymore and the developer using this library gets a nice stack trace as well making debugging easier.