### PR TITLE
order.fetchTransfers|fetch all transfers for a given order

### DIFF
--- a/dist/api.js
+++ b/dist/api.js
@@ -67,7 +67,9 @@ var API = function () {
     }
   }, {
     key: 'post',
-    value: function post(params, cb, isNotForm = false) {
+    value: function post(params, cb) {
+      var isNotForm = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
+
       var request = {
         url: params.url,
         form: params.data

--- a/dist/razorpay.d.ts
+++ b/dist/razorpay.d.ts
@@ -1,1 +1,0 @@
-declare module "razorpay";

--- a/dist/resources/orders.js
+++ b/dist/resources/orders.js
@@ -111,6 +111,16 @@ module.exports = function (api) {
       return api.get({
         url: '/orders/' + orderId + '/payments'
       }, callback);
+    },
+
+    fetchTransfers: function fetchTransfers(orderId, callback) {
+      if (!orderId) {
+        throw new Error('`order_id` is mandatory');
+      }
+
+      return api.get({
+        url: '/orders/' + orderId + '?expand[]=transfers'
+      }, callback);
     }
   };
 };

--- a/lib/resources/orders.js
+++ b/lib/resources/orders.js
@@ -44,7 +44,7 @@ module.exports = function (api) {
 
     create(params = {}, callback) {
       let { amount, currency, receipt, payment_capture, notes, method,
-            ...otherParams } = params
+        ...otherParams } = params
       currency = currency || 'INR'
 
       if (!(amount || (method === 'emandate' && amount === 0))) {
@@ -65,10 +65,10 @@ module.exports = function (api) {
         data
       }, callback)
     },
-    
+
     edit(orderId, params = {}, callback) {
       let { notes } = params
-      
+
       if (!orderId) {
         throw new Error('`order_id` is mandatory')
       }
@@ -89,6 +89,15 @@ module.exports = function (api) {
       return api.get({
         url: `/orders/${orderId}/payments`
       }, callback)
+    },
+    fetchTransfers: function fetchTransfers(orderId, callback) {
+      if (!orderId) {
+        throw new Error('`order_id` is mandatory');
+      }
+
+      return api.get({
+        url: '/orders/' + orderId + '?expand[]=transfers'
+      }, callback);
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "razorpay",
-  "version": "2.0.7",
+  "version": "2.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
As per documentation @ https://github.com/razorpay/razorpay-node/blob/master/documents/transfer.md,
```
instance.orders.transfers({
  "expand[]": "transfers"
})
```
results in "orders.transfers is not a function" error

This PR adds a function `fetchTransfers` to orders, allowing to fetch transfers for a given order id as follows,
```
instance.orders.fetchTransfers(
        "order_xxxxxxxxxxx"
    );
```

Thats all folks! 