### PR TITLE
feat(stale): Stale implementation for issues and pr

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '29 1 * * *' # Runs at 01:29 UTC every day.
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days'
+        stale-pr-message: 'This Pr is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days'
+        stale-issue-label: 'Stale'
+        stale-pr-label: 'Stale'
+        days-before-stale: 30
+        days-before-close: 7
+Footer


### PR DESCRIPTION
# Stale
Whenever an issue or Pull Request has not been updated for a while, a stale label will be placed to mark it as stale. A closing comment may also be posted to notify contributors.

The stale label is removed if the Issue or Pull Request is updated, or if anyone comments on it.

Use the official Stale action located at https://github.com/actions/stale