### PR TITLE
fix: move typescript to dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,18 @@
 {
   "name": "razorpay",
-  "version": "2.8.6",
+  "version": "2.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "razorpay",
-      "version": "2.8.6",
+      "version": "2.9.2",
       "license": "MIT",
       "dependencies": {
         "@types/request-promise": "^4.1.48",
         "promise": "^8.1.0",
         "request": "^2.88.0",
-        "request-promise": "^4.2.6",
-        "typescript": "^4.9.4"
+        "request-promise": "^4.2.6"
       },
       "devDependencies": {
         "babel-cli": "^6.26.0",
@@ -24,7 +23,8 @@
         "deep-equal": "^2.0.5",
         "mocha": "^9.0.0",
         "nock": "^13.1.1",
-        "nyc": "^15.1.0"
+        "nyc": "^15.1.0",
+        "typescript": "^4.9.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7073,6 +7073,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13081,7 +13082,8 @@
     "typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "prepublish": "npm test",
     "clean": "rm -rf dist && mkdir dist",
-    "cp-types":"mkdir dist/types && cp lib/types/* dist/types && cp lib/utils/*d.ts dist/utils",
+    "cp-types": "mkdir dist/types && cp lib/types/* dist/types && cp lib/utils/*d.ts dist/utils",
     "cp-ts": "cp lib/razorpay.d.ts dist/ && npm run cp-types",
     "build:commonjs": "babel lib -d dist",
     "build": "npm run clean && npm run build:commonjs && npm run cp-ts",
@@ -43,13 +43,13 @@
     "deep-equal": "^2.0.5",
     "mocha": "^9.0.0",
     "nock": "^13.1.1",
-    "nyc": "^15.1.0"
+    "nyc": "^15.1.0",
+    "typescript": "^4.9.4"
   },
   "dependencies": {
     "@types/request-promise": "^4.1.48",
     "promise": "^8.1.0",
     "request": "^2.88.0",
-    "request-promise": "^4.2.6",
-    "typescript": "^4.9.4"
+    "request-promise": "^4.2.6"
   }
 }


### PR DESCRIPTION
When using this library incontext of deno, typescript is getting bundled, so moving typescript to dev dependency


Output when running `deno info filename`
```
├─┬ npm:/razorpay@2.9.2 (280.17KB)
│ ├─┬ npm:/@types/request-promise@4.1.51 (6.08KB)
│ │ ├── npm:/@types/bluebird@3.5.42 (59.54KB)
│ │ └─┬ npm:/@types/request@2.48.12 (19.32KB)
│ │   ├── npm:/@types/caseless@0.12.5 (4.61KB)
│ │   ├── npm:/@types/node@18.16.19 (3.51MB)
│ │   ├── npm:/@types/tough-cookie@4.0.5 (13.22KB)
│ │   └─┬ npm:/form-data@2.5.1 (40.37KB)
│ │     ├── npm:/asynckit@0.4.0 (26.72KB)
│ │     ├─┬ npm:/combined-stream@1.0.8 (11.24KB)
│ │     │ └── npm:/delayed-stream@1.0.0 (7.83KB)
│ │     └─┬ npm:/mime-types@2.1.35 (17.84KB)
│ │       └── npm:/mime-db@1.52.0 (200.72KB)
│ ├─┬ npm:/promise@8.3.0 (106.82KB)
│ │ └── npm:/asap@2.0.6 (33.12KB)
│ ├─┬ npm:/request@2.88.2 (204.38KB)
│ │ ├── npm:/aws-sign2@0.7.0 (13.85KB)
│ │ ├── npm:/aws4@1.12.0 (22.96KB)
│ │ ├── npm:/caseless@0.12.0 (13.92KB)
│ │ ├── npm:/combined-stream@1.0.8 (11.24KB) *
│ │ ├── npm:/extend@3.0.2 (22.91KB)
│ │ ├── npm:/forever-agent@0.6.1 (13.68KB)
│ │ ├─┬ npm:/form-data@2.3.3 (116.44KB)
│ │ │ ├── npm:/asynckit@0.4.0 (26.72KB)
│ │ │ ├── npm:/combined-stream@1.0.8 (11.24KB) *
│ │ │ └── npm:/mime-types@2.1.35 (17.84KB) *
│ │ ├─┬ npm:/har-validator@5.1.5 (8.03KB)
│ │ │ ├─┬ npm:/ajv@6.12.6 (907.38KB)
│ │ │ │ ├── npm:/fast-deep-equal@3.1.3 (12.66KB)
│ │ │ │ ├── npm:/fast-json-stable-stringify@2.1.0 (16.56KB)
│ │ │ │ ├── npm:/json-schema-traverse@0.4.1 (19.11KB)
│ │ │ │ └─┬ npm:/uri-js@4.4.1 (458.87KB)
│ │ │ │   └── npm:/punycode@2.3.1 (32.73KB)
│ │ │ └── npm:/har-schema@2.0.0 (14.75KB)
│ │ ├─┬ npm:/http-signature@1.2.0 (47.28KB)
│ │ │ ├── npm:/assert-plus@1.0.0 (11.17KB)
│ │ │ ├─┬ npm:/jsprim@1.4.2 (30.45KB)
│ │ │ │ ├── npm:/assert-plus@1.0.0 (11.17KB)
│ │ │ │ ├── npm:/extsprintf@1.3.0 (22.27KB)
│ │ │ │ ├── npm:/json-schema@0.4.0 (25.47KB)
│ │ │ │ └─┬ npm:/verror@1.10.0 (35KB)
│ │ │ │   ├── npm:/assert-plus@1.0.0 (11.17KB)
│ │ │ │   ├── npm:/core-util-is@1.0.2 (22.65KB)
│ │ │ │   └── npm:/extsprintf@1.3.0 (22.27KB)
│ │ │ └─┬ npm:/sshpk@1.18.0 (225.44KB)
│ │ │   ├─┬ npm:/asn1@0.2.6 (19.29KB)
│ │ │   │ └── npm:/safer-buffer@2.1.2 (41.31KB)
│ │ │   ├── npm:/assert-plus@1.0.0 (11.17KB)
│ │ │   ├─┬ npm:/bcrypt-pbkdf@1.0.2 (28.31KB)
│ │ │   │ └── npm:/tweetnacl@0.14.5 (169.97KB)
│ │ │   ├─┬ npm:/dashdash@1.14.1 (78.75KB)
│ │ │   │ └── npm:/assert-plus@1.0.0 (11.17KB)
│ │ │   ├─┬ npm:/ecc-jsbn@0.1.2 (27.15KB)
│ │ │   │ ├── npm:/jsbn@0.1.1 (44.77KB)
│ │ │   │ └── npm:/safer-buffer@2.1.2 (41.31KB)
│ │ │   ├─┬ npm:/getpass@0.1.7 (5.54KB)
│ │ │   │ └── npm:/assert-plus@1.0.0 (11.17KB)
│ │ │   ├── npm:/jsbn@0.1.1 (44.77KB)
│ │ │   ├── npm:/safer-buffer@2.1.2 (41.31KB)
│ │ │   └── npm:/tweetnacl@0.14.5 (169.97KB)
│ │ ├── npm:/is-typedarray@1.0.0 (4.3KB)
│ │ ├── npm:/isstream@0.1.2 (13KB)
│ │ ├── npm:/json-stringify-safe@5.0.1 (12.42KB)
│ │ ├── npm:/mime-types@2.1.35 (17.84KB) *
│ │ ├── npm:/oauth-sign@0.9.0 (13.48KB)
│ │ ├── npm:/performance-now@2.1.0 (11.08KB)
│ │ ├── npm:/qs@6.5.3 (122.71KB)
│ │ ├── npm:/safe-buffer@5.2.1 (31.35KB)
│ │ ├─┬ npm:/tough-cookie@2.5.0 (84.61KB)
│ │ │ ├── npm:/psl@1.9.0 (450.63KB)
│ │ │ └── npm:/punycode@2.3.1 (32.73KB)
│ │ ├─┬ npm:/tunnel-agent@0.6.0 (16.29KB)
│ │ │ └── npm:/safe-buffer@5.2.1 (31.35KB)
│ │ └── npm:/uuid@3.4.0 (33.47KB)
│ ├─┬ npm:/request-promise@4.2.6_request@2.88.2 (36.54KB)
│ │ ├── npm:/bluebird@3.7.2 (617.56KB)
│ │ ├── npm:/request@2.88.2 (204.38KB) *
│ │ ├─┬ npm:/request-promise-core@1.1.4_request@2.88.2 (19.21KB)
│ │ │ ├── npm:/lodash@4.17.21 (1.35MB)
│ │ │ └── npm:/request@2.88.2 (204.38KB) *
│ │ ├── npm:/stealthy-require@1.1.1 (12.21KB)
│ │ └── npm:/tough-cookie@2.5.0 (84.61KB) *
│ └── npm:/typescript@4.9.5 (63.75MB)
└── npm:/razorpay@2.9.2 
```