### PR TITLE
fix: wrong types definition specified for class field

### DIFF
--- a/lib/types/customers.d.ts
+++ b/lib/types/customers.d.ts
@@ -25,7 +25,7 @@ export declare namespace Customers {
          *
          * `1` (default): If a customer with the same details already exists, throws an error.
          */
-        fail_existing?: boolean | 0 | 1;
+        fail_existing?: "0" | "1";
         /**
          * Customer's GST number, if available
          */


### PR DESCRIPTION
According to [official docs for customer creation](https://razorpay.com/docs/api/customers/create/) using razorpay API, `fail_existing` should be a string.

But the types defined were `boolean`, numeric `1` & `0`.

fixes #377, fixes #381