### PR TITLE
[CEPF-1767]: Remove type check validation

### DIFF
--- a/lib/resources/subscriptions.js
+++ b/lib/resources/subscriptions.js
@@ -246,12 +246,6 @@ module.exports = function subscriptionsApi (api) {
         return Promise.reject(MISSING_ID_ERROR);
       }
 
-      if (typeof cancelAtCycleEnd !== "boolean") {
-      
-        return Promise.reject("The second parameter, Cancel at the end of cycle" +
-                              " should be a Boolean");
-      }
-
       return api.post({
         url,
         ...(cancelAtCycleEnd && {data: {cancel_at_cycle_end: 1}})

--- a/lib/types/subscriptions.d.ts
+++ b/lib/types/subscriptions.d.ts
@@ -356,11 +356,11 @@ declare function subscriptions(api: any): {
     * Cancel a subscription given id and optional cancelAtCycleEnd
     *
     * @param subscriptionId - The unique identifier of the Subscription.
-    * @param cancelAtCycleEnd - `false` (default): Cancel the subscription immediately.
+    * @param cancelAtCycleEnd - `false` or `0` (default): Cancel the subscription immediately.
     * 
     */
-    cancel(subscriptionId: string, cancelAtCycleEnd?: boolean): Promise<Subscriptions.RazorpaySubscription>
-    cancel(subscriptionId: string, cancelAtCycleEnd: boolean, callback: (err: INormalizeError | null, data: Subscriptions.RazorpaySubscription) => void): void;
+    cancel(subscriptionId: string, cancelAtCycleEnd?: boolean | number): Promise<Subscriptions.RazorpaySubscription>
+    cancel(subscriptionId: string, cancelAtCycleEnd: boolean| number, callback: (err: INormalizeError | null, data: Subscriptions.RazorpaySubscription) => void): void;
     /**
     * Delete offer linked to a subscription
     *


### PR DESCRIPTION
Doc reference: https://razorpay.com/docs/api/payments/subscriptions/cancel-subscription/

WIll work with both `number` & `boolean`
```
instance.subscriptions.cancel("sub_PC5WEB7pL8N9Bi", 1)
```
or
```
instance.subscriptions.cancel("sub_PC5WEB7pL8N9Bi", true)
```