### PR TITLE
[FIX] validateWebhookSignature possible timing attack

### DIFF
--- a/lib/utils/razorpay-utils.js
+++ b/lib/utils/razorpay-utils.js
@@ -80,8 +80,6 @@ function validateWebhookSignature (body, signature, secret) {
    * @return {Boolean}
    */
 
-  var crypto = require("crypto");
-
   if (!isDefined(body)      ||
       !isDefined(signature) ||
       !isDefined(secret)      ) {
@@ -98,8 +96,15 @@ function validateWebhookSignature (body, signature, secret) {
   var expectedSignature = crypto.createHmac('sha256', secret)
                                 .update(body)
                                 .digest('hex');
+  
+  const signatureBuffer = Buffer.from(signature);
+  const expectedSignatureBuffer = Buffer.from(expectedSignature);
 
-  return expectedSignature === signature;
+  if (signatureBuffer.length !== expectedSignatureBuffer.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(signatureBuffer, expectedSignatureBuffer);
 }
 
 function validatePaymentVerification(params={}, signature, secret){


### PR DESCRIPTION
validateWebhookSignature had simple `===` compare for signature matching - this could lead to timing attacks.
following what stripe does in it's extension - replicating crypto libraries timing safe equality operator.

Fixes: #462 