### PR TITLE
fix: prevent timing attack in webhook signature verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x, 19,x]
+        node-version: [12.x, 14.x, 16.x, 18.x, 19.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/    
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
         node-version: [12.x, 14.x, 16.x, 18.x, 19.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/    
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'  
@@ -40,9 +40,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: sudo apt-get install -y oathtool
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -20,9 +20,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/lib/utils/razorpay-utils.js
+++ b/lib/utils/razorpay-utils.js
@@ -99,7 +99,16 @@ function validateWebhookSignature (body, signature, secret) {
                                 .update(body)
                                 .digest('hex');
 
-  return expectedSignature === signature;
+  // Use constant-time comparison to prevent timing attacks
+  var expectedBuffer = Buffer.from(expectedSignature, 'utf8');
+  var signatureBuffer = Buffer.from(signature, 'utf8');
+
+  // timingSafeEqual requires equal length buffers
+  if (expectedBuffer.length !== signatureBuffer.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(expectedBuffer, signatureBuffer);
 }
 
 function validatePaymentVerification(params={}, signature, secret){

--- a/lib/utils/razorpay-utils.js
+++ b/lib/utils/razorpay-utils.js
@@ -101,12 +101,9 @@ function validateWebhookSignature (body, signature, secret) {
                              .digest();
 
   // Decode incoming hex signature to raw bytes
-  var signatureBuffer;
-  try {
-    signatureBuffer = Buffer.from(signature, 'hex');
-  } catch (e) {
-    return false;
-  }
+  // Note: Buffer.from(hex) returns empty/partial Buffer on invalid hex (no throw),
+  // which is caught by the length check below
+  var signatureBuffer = Buffer.from(signature, 'hex');
 
   // Both should be 32 bytes (SHA-256 output)
   if (expectedBuffer.length !== signatureBuffer.length) {

--- a/lib/utils/razorpay-utils.js
+++ b/lib/utils/razorpay-utils.js
@@ -95,19 +95,25 @@ function validateWebhookSignature (body, signature, secret) {
 
   body = body.toString();
 
-  var expectedSignature = crypto.createHmac('sha256', secret)
-                                .update(body)
-                                .digest('hex');
+  // Compute HMAC as raw bytes (32 bytes for SHA-256)
+  var expectedBuffer = crypto.createHmac('sha256', secret)
+                             .update(body)
+                             .digest();
 
-  // Use constant-time comparison to prevent timing attacks
-  var expectedBuffer = Buffer.from(expectedSignature, 'utf8');
-  var signatureBuffer = Buffer.from(signature, 'utf8');
+  // Decode incoming hex signature to raw bytes
+  var signatureBuffer;
+  try {
+    signatureBuffer = Buffer.from(signature, 'hex');
+  } catch (e) {
+    return false;
+  }
 
-  // timingSafeEqual requires equal length buffers
+  // Both should be 32 bytes (SHA-256 output)
   if (expectedBuffer.length !== signatureBuffer.length) {
     return false;
   }
 
+  // Constant-time comparison to prevent timing attacks
   return crypto.timingSafeEqual(expectedBuffer, signatureBuffer);
 }
 


### PR DESCRIPTION
Replace vulnerable string comparison (===) with crypto.timingSafeEqual() to prevent timing-based side-channel attacks on signature verification.

The === operator short-circuits on first mismatch, allowing attackers to measure response times and potentially guess signatures character by character. timingSafeEqual() always compares all bytes in constant time regardless of input.

## Note :- Please follow the below points while attaching test cases document link below:
   ### - If label `Tested` is added then test cases document URL is mandatory.
   ### - Link added should be a valid URL and accessible throughout the org.
   ### - If the branch name contains hotfix / revert by default the BVT workflow check will pass.

| Test Case Document URL                        |
|-----------------------------------------------|
https://docs.google.com/document/d/1RA9GcYqNGnUcQjIYAF0jxBa-DYw_iHRqMMMe-t_c3IE/edit?usp=sharing
