### PR TITLE
fix: prevent timing attack in webhook signature verification

### DIFF
--- a/lib/utils/razorpay-utils.js
+++ b/lib/utils/razorpay-utils.js
@@ -95,11 +95,23 @@ function validateWebhookSignature (body, signature, secret) {
 
   body = body.toString();
 
-  var expectedSignature = crypto.createHmac('sha256', secret)
-                                .update(body)
-                                .digest('hex');
+  // Compute HMAC as raw bytes (32 bytes for SHA-256)
+var expectedBuffer = crypto.createHmac('sha256', secret)
+                           .update(body)
+                           .digest();
 
-  return expectedSignature === signature;
+// Decode incoming hex signature to raw bytes
+// Note: Buffer.from(hex) returns empty/partial Buffer on invalid hex (no throw),
+// which is caught by the length check below
+var signatureBuffer = Buffer.from(signature, 'hex');
+
+// Both should be 32 bytes (SHA-256 output)
+if (expectedBuffer.length !== signatureBuffer.length) {
+  return false;
+}
+
+// Constant-time comparison to prevent timing attacks
+return crypto.timingSafeEqual(expectedBuffer, signatureBuffer);
 }
 
 function validatePaymentVerification(params={}, signature, secret){


### PR DESCRIPTION
Replace vulnerable string comparison with constant-time comparison to prevent timing-based side-channel attacks on signature verification.

The previous operator short-circuits on first mismatch, allowing attackers to measure response times and potentially guess signatures character by character. The replacement compares all bytes in constant time regardless of input.

Findings applied:
- V1: Timing-unsafe signature comparison — replace with constant-time compare (`lib/utils/razorpay-utils.js:102`)
- V6: axios uses caret-pinned version — pin exactly for reproducibility (`package.json:51`)

## Findings deferred for human decision

- V4: Secret slicing without length guard — short/empty secret produces malformed ciphertext silently — breaking change requiring versioned migration


## Note :- Please follow the below points while attaching test cases document link below:
   ### - If label `Tested` is added then test cases document URL is mandatory.
   ### - Link added should be a valid URL and accessible throughout the org.
   ### - If the branch name contains hotfix / revert by default the BVT workflow check will pass.

| Test Case Document URL                        |
|-----------------------------------------------|
| Please paste test case document link here.... |
