### PR TITLE
fix(types): allow string '0' | '1' for fail_existing on customers.create

### DIFF
--- a/lib/types/customers.d.ts
+++ b/lib/types/customers.d.ts
@@ -25,7 +25,7 @@ export declare namespace Customers {
          *
          * `1` (default): If a customer with the same details already exists, throws an error.
          */
-        fail_existing?: boolean | 0 | 1;
+        fail_existing?: boolean | 0 | 1 | '0' | '1';
         /**
          * Customer's GST number, if available
          */


### PR DESCRIPTION
Fixes #463.

The Razorpay Customers API accepts `fail_existing` as either a string (`'0'` / `'1'`), a number (`0` / `1`), or a boolean, but the current TypeScript declaration only allows the boolean / numeric forms. TypeScript users who pass the string form (matching what the docs show) get a type error.

Widens the type to include `'0' | '1'`. Single line change in `lib/types/customers.d.ts`. No runtime code touched.