### PR TITLE
chore(deps): bump axios to ^1.8.2 for GHSA-jr5f-v2jv-69x6

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "axios": "^1.6.8"
+    "axios": "^1.8.2"
   }
 }


### PR DESCRIPTION
Addresses #439.

`package.json` currently pins `axios: ^1.6.8`, and the resolved version in `package-lock.json` is `1.6.8`. That version is affected by [GHSA-jr5f-v2jv-69x6](https://github.com/axios/axios/security/advisories/GHSA-jr5f-v2jv-69x6) (SSRF / credential leakage via absolute URL in requests). The fix landed in axios 1.8.2.

Bumps the constraint to `^1.8.2`. Only `package.json` is changed — I didn't run `npm install` here, so the lockfile is not regenerated in this commit. Happy to push a lockfile update separately if you'd prefer it in this PR.