### PR TITLE
bump version v2.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.9.7 - 2026-06-10
+fix: Use random nonce per call in AES-GCM onboarding signature
+ci: Bump checkout/setup-node actions to v4
+
 ## 2.9.6 - 2025-02-24
 feat: Added support for access token based authentication mechanism
 - Added oauth APIs (getAuthURL, getAccessToken, refreshToken, revokeToken)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 2.9.7 - 2026-06-10
 fix: Use random nonce per call in AES-GCM onboarding signature
-ci: Bump checkout/setup-node actions to v4
 
 ## 2.9.6 - 2025-02-24
 feat: Added support for access token based authentication mechanism

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "razorpay",
-  "version": "2.9.4",
+  "version": "2.9.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "razorpay",
-      "version": "2.9.4",
+      "version": "2.9.7",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "razorpay",
-  "version": "2.9.6",
+  "version": "2.9.7",
   "description": "Official Node SDK for Razorpay API",
   "main": "dist/razorpay",
   "typings": "dist/razorpay",


### PR DESCRIPTION

## 2.9.7 - 2026-06-10
fix: Use random nonce per call in AES-GCM onboarding signature