### PR TITLE
Normalize from/to dates in QR code, settlement & refund list endpoints

### DIFF
--- a/lib/resources/payments.js
+++ b/lib/resources/payments.js
@@ -141,6 +141,14 @@ module.exports = function (api) {
       let { from, to, count, skip } = params,
           url = `${BASE_URL}/${paymentId}/refunds`;
 
+      if (from) {
+        from = normalizeDate(from)
+      }
+
+      if (to) {
+        to = normalizeDate(to)
+      }
+
       return api.get({
         url,
         data: {

--- a/lib/resources/qrCode.js
+++ b/lib/resources/qrCode.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { normalizeDate } = require('../utils/razorpay-utils')
+
 module.exports = function (api) {
 
   const BASE_URL = "/payments/qr_codes";
@@ -36,7 +38,15 @@ module.exports = function (api) {
   
         let { from, to, count, skip } = params,
             url = BASE_URL;
-  
+
+        if (from) {
+          from = normalizeDate(from)
+        }
+
+        if (to) {
+          to = normalizeDate(to)
+        }
+
         return api.get({
           url,
           data: {
@@ -61,7 +71,15 @@ module.exports = function (api) {
   
         let { from, to, count, skip } = params,
             url = `${BASE_URL}/${qrCodeId}/payments`;
-  
+
+        if (from) {
+          from = normalizeDate(from)
+        }
+
+        if (to) {
+          to = normalizeDate(to)
+        }
+
         return api.get({
           url,
           data: {

--- a/lib/resources/settlements.js
+++ b/lib/resources/settlements.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { normalizeDate } = require('../utils/razorpay-utils')
+
 module.exports = function (api) {
 
   const BASE_URL = "/settlements";
@@ -36,7 +38,15 @@ module.exports = function (api) {
   
         let { from, to, count, skip } = params,
             url = BASE_URL;
-  
+
+        if (from) {
+          from = normalizeDate(from)
+        }
+
+        if (to) {
+          to = normalizeDate(to)
+        }
+
         return api.get({
           url,
           data: {
@@ -109,7 +119,15 @@ module.exports = function (api) {
         let expand ;
         let { from, to, count, skip } = params,
             url = `${BASE_URL}/ondemand`;
-        
+
+        if (from) {
+          from = normalizeDate(from)
+        }
+
+        if (to) {
+          to = normalizeDate(to)
+        }
+
         if(params.hasOwnProperty("expand[]")) {
           expand = { "expand[]" : params["expand[]"] }
         }

--- a/test/resources/payments.spec.js
+++ b/test/resources/payments.spec.js
@@ -72,6 +72,37 @@ describe('PAYMENTS', () => {
     })
   })
 
+  describe('Fetch multiple refunds for a payment', () => {
+    it('`From` & `To` dates are converted to seconds', (done) => {
+      let fromDate = 'Aug 25, 2016'
+      let toDate = 'Aug 30, 2016'
+      let fromDateInSecs = getDateInSecs(fromDate)
+      let toDateInSecs = getDateInSecs(toDate)
+
+      mocker.mock({
+        url: `/payments/${TEST_PAYMENT_ID}/refunds`
+      })
+
+      rzpInstance.payments.fetchMultipleRefund(TEST_PAYMENT_ID, {
+        from: fromDate,
+        to: toDate,
+        count: 25,
+        skip: 5
+      }).then((response) => {
+        assert.ok(equal(
+          response.__JUST_FOR_TESTS__.requestQueryParams,
+          {
+            from: fromDateInSecs,
+            to: toDateInSecs,
+            count: 25,
+            skip: 5
+          }
+        ), 'from & to dates are converted to seconds')
+        done()
+      })
+    })
+  })
+
   describe('Payment fetch', () => {
     it('Throw error when paymentId is not provided', () => {
       assert.throws(

--- a/test/resources/qrCode.spec.js
+++ b/test/resources/qrCode.spec.js
@@ -336,5 +336,48 @@ describe('QRCODE ', () => {
         mockerParams,
         methodArgs
       });
+
+      it('`From` & `To` dates are converted to seconds', (done) => {
+        let fromDate = 'Aug 25, 2016'
+        let toDate = 'Aug 30, 2016'
+        let fromDateInSecs = getDateInSecs(fromDate)
+        let toDateInSecs = getDateInSecs(toDate)
+
+        mocker.mock({
+          url: `${SUB_PATH}/${TEST_QRCODE_ID}/payments`
+        })
+
+        rzpInstance.qrCode.fetchAllPayments(TEST_QRCODE_ID, {
+          from: fromDate,
+          to: toDate
+        }).then((response) => {
+          assert.equal(response.__JUST_FOR_TESTS__.requestQueryParams.from, fromDateInSecs)
+          assert.equal(response.__JUST_FOR_TESTS__.requestQueryParams.to, toDateInSecs)
+          done()
+        })
+      });
+  });
+
+  describe("Fetch all QrCode date normalization", () => {
+
+      it('`From` & `To` dates are converted to seconds', (done) => {
+        let fromDate = 'Aug 25, 2016'
+        let toDate = 'Aug 30, 2016'
+        let fromDateInSecs = getDateInSecs(fromDate)
+        let toDateInSecs = getDateInSecs(toDate)
+
+        mocker.mock({
+          url: SUB_PATH
+        })
+
+        rzpInstance.qrCode.all({
+          from: fromDate,
+          to: toDate
+        }).then((response) => {
+          assert.equal(response.__JUST_FOR_TESTS__.requestQueryParams.from, fromDateInSecs)
+          assert.equal(response.__JUST_FOR_TESTS__.requestQueryParams.to, toDateInSecs)
+          done()
+        })
+      });
   });
 });

--- a/test/resources/settlements.spec.js
+++ b/test/resources/settlements.spec.js
@@ -4,6 +4,8 @@ const chai = require('chai')
 const { assert } = chai
 const rzpInstance = require('../razorpay')
 const mocker = require('../mocker')
+const equal = require('deep-equal')
+const { getDateInSecs } = require('../../dist/utils/razorpay-utils')
 const { runCallbackCheckTest,
     runParamsCheckTest }  = require("../../dist/utils/predefined-tests.js");
 
@@ -119,6 +121,35 @@ describe("Fetch all settlements", () => {
         mockerParams,
         methodArgs
       });
+
+      it('`From` & `To` dates are converted to seconds', (done) => {
+        let fromDate = 'Aug 25, 2016'
+        let toDate = 'Aug 30, 2016'
+        let fromDateInSecs = getDateInSecs(fromDate)
+        let toDateInSecs = getDateInSecs(toDate)
+
+        mocker.mock({
+          url: SUB_PATH
+        })
+
+        rzpInstance.settlements.all({
+          from: fromDate,
+          to: toDate,
+          count: 25,
+          skip: 5
+        }).then((response) => {
+          assert.ok(equal(
+            response.__JUST_FOR_TESTS__.requestQueryParams,
+            {
+              from: fromDateInSecs,
+              to: toDateInSecs,
+              count: 25,
+              skip: 5
+            }
+          ), 'from & to dates are converted to seconds')
+          done()
+        })
+      });
   });
 
   describe("Settlement report for a month", () => {
@@ -191,6 +222,34 @@ describe("Fetch all settlements", () => {
         methodName,
         mockerParams,
         methodArgs
+      });
+
+      it('`From` & `To` dates are converted to seconds', (done) => {
+        let fromDate = 'Aug 25, 2016'
+        let toDate = 'Aug 30, 2016'
+        let fromDateInSecs = getDateInSecs(fromDate)
+        let toDateInSecs = getDateInSecs(toDate)
+
+        mocker.mock({
+          url: `${SUB_PATH}/ondemand`
+        })
+
+        rzpInstance.settlements.fetchAllOndemandSettlement({
+          from: fromDate,
+          to: toDate,
+          count: 25,
+          skip: 5
+        }).then((response) => {
+          assert.ok(equal(
+            response.__JUST_FOR_TESTS__.requestQueryParams.from,
+            fromDateInSecs
+          ), 'from date is converted to seconds')
+          assert.ok(equal(
+            response.__JUST_FOR_TESTS__.requestQueryParams.to,
+            toDateInSecs
+          ), 'to date is converted to seconds')
+          done()
+        })
       });
   });
 });


### PR DESCRIPTION
## Summary

Five list endpoints destructure `{ from, to, count, skip }` from `params` and then spread them straight back into the request as `{ ...params, from, to, count, skip }` — a no-op that **never calls `normalizeDate`**:

- `payments.fetchMultipleRefund`
- `qrCode.all`
- `qrCode.fetchAllPayments`
- `settlements.all`
- `settlements.fetchAllOndemandSettlement`

Every other list endpoint (`orders.all`, `payments.all`, `items.all`, `invoices.all`, `addons.all`) normalizes `from`/`to` so a `Date`/date-string is converted to epoch seconds. These five silently skip that, so passing a human-readable date sends an unconverted value to the API and the date filter is wrong.

## Fix

Call `normalizeDate` on `from`/`to` in the five methods (adding the util import to `qrCode.js` and `settlements.js`). `normalizeDate` passes numeric timestamps through unchanged, so this is **backward compatible** for callers already sending epoch seconds.

## Tests

Added regression tests asserting `from`/`to` are converted to seconds for each fixed method. Verified they **fail without** the source change and **pass with** it. Full suite: `384 passing`.
