### PR TITLE
Normalize `authorized` boolean to 1/0 in orders.all() (fixes dead normalizeBoolean)

### DIFF
--- a/lib/resources/orders.js
+++ b/lib/resources/orders.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { normalizeDate } = require('../utils/razorpay-utils')
+const { normalizeDate, normalizeBoolean } = require('../utils/razorpay-utils')
 
 module.exports = function (api) {
   return {
@@ -22,7 +22,7 @@ module.exports = function (api) {
 
       count = Number(count) || 10
       skip = Number(skip) || 0
-      authorized = authorized
+      authorized = normalizeBoolean(authorized)
 
       return api.get({
         url: '/orders',

--- a/test/resources/orders.spec.js
+++ b/test/resources/orders.spec.js
@@ -67,6 +67,40 @@ describe('ORDERS', () => {
         done()
       })
     })
+
+    it('`authorized` boolean is normalized to 1/0', (done) => {
+      mocker.mock({
+        url: '/orders'
+      })
+
+      rzpInstance.orders.all({
+        authorized: true
+      }).then((response) => {
+        assert.strictEqual(
+          response.__JUST_FOR_TESTS__.requestQueryParams.authorized,
+          '1',
+          '`authorized: true` is sent to the API as 1'
+        )
+        done()
+      }).catch(done)
+    })
+
+    it('`authorized: false` is normalized to 0', (done) => {
+      mocker.mock({
+        url: '/orders'
+      })
+
+      rzpInstance.orders.all({
+        authorized: false
+      }).then((response) => {
+        assert.strictEqual(
+          response.__JUST_FOR_TESTS__.requestQueryParams.authorized,
+          '0',
+          '`authorized: false` is sent to the API as 0'
+        )
+        done()
+      }).catch(done)
+    })
   })
 
   describe('Order fetch', () => {


### PR DESCRIPTION
## Summary

`orders.all()` accepts `authorized` (typed as `boolean | 1 | 0`), and the [Orders API](https://razorpay.com/docs/api/orders/fetch-all/) expects `1`/`0`. The method contained a no-op self-assignment:

```js
authorized = authorized
```

where the `normalizeBoolean` conversion was clearly intended. As a side effect, `normalizeBoolean` is exported from `razorpay-utils` but **never called anywhere** in the library. So passing `authorized: true` sent the raw boolean to the API instead of `1`.

The existing test only exercised `authorized: 1` (already binary), so its own assertion message — *"authorized to binary"* — passed by accident and the bug slipped through.

## Fix

```js
authorized = normalizeBoolean(authorized)
```

(imported into `orders.js`). `normalizeBoolean(undefined)` returns `undefined`, so callers that omit the flag are unaffected, and `1`/`0` pass through unchanged — **backward compatible**.

## Tests

Added tests exercising `authorized: true` → `1` and `authorized: false` → `0`. Verified they **fail without** the fix and **pass with** it. Full suite: `386 passing`.
