### PR TITLE
Support expand[] in orders.fetch and send expand[] the way the API expects (#332)

### DIFF
--- a/documents/order.md
+++ b/documents/order.md
@@ -148,6 +148,13 @@ instance.orders.fetch(orderId)
 | Name     | Type   | Description                         |
 |----------|--------|-------------------------------------|
 | orderId* | string | The id of the order to be fetched |
+| expand[] | string | Used to retrieve additional information about the order. Possible value is `payments`,`payments.card`,`transfers` or `virtual_account` |
+
+For example, to include the order's payments in the response:
+
+```js
+instance.orders.fetch(orderId, { "expand[]": "payments" })
+```
 
 **Response:**
 

--- a/lib/resources/orders.js
+++ b/lib/resources/orders.js
@@ -17,7 +17,7 @@ module.exports = function (api) {
       }
 
       if(params.hasOwnProperty("expand[]")) {
-        expand = { "expand[]" : params["expand[]"] }
+        expand = params["expand[]"]
       }
 
       count = Number(count) || 10
@@ -33,18 +33,32 @@ module.exports = function (api) {
           skip,
           authorized,
           receipt,
-          expand
+          "expand[]": expand
         }
       }, callback)
     },
 
-    fetch(orderId, callback) {
+    fetch(orderId, params = {}, callback) {
+      let expand ;
+
+      if (typeof params === 'function') {
+        callback = params
+        params = {}
+      }
+
       if (!orderId) {
         throw new Error('`order_id` is mandatory')
       }
 
+      if(params.hasOwnProperty("expand[]")) {
+        expand = params["expand[]"]
+      }
+
       return api.get({
-        url: `/orders/${orderId}`
+        url: `/orders/${orderId}`,
+        data: {
+          "expand[]": expand
+        }
       }, callback)
     },
 

--- a/lib/resources/payments.js
+++ b/lib/resources/payments.js
@@ -21,7 +21,7 @@ module.exports = function (api) {
       }
 
       if(params.hasOwnProperty("expand[]")) {
-        expand = { "expand[]" : params["expand[]"] }
+        expand = params["expand[]"]
       }
 
       count = Number(count) || 10
@@ -34,7 +34,7 @@ module.exports = function (api) {
           to,
           count,
           skip,
-          expand
+          "expand[]": expand
         }
       }, callback)
     },
@@ -47,13 +47,13 @@ module.exports = function (api) {
       }
 
       if(params.hasOwnProperty("expand[]")) {
-        expand = { "expand[]" : params["expand[]"] }
+        expand = params["expand[]"]
       }
 
       return api.get({
         url: `${BASE_URL}/${paymentId}`,
         data: {
-          expand
+          "expand[]": expand
         }
       }, callback)
     },

--- a/lib/resources/settlements.js
+++ b/lib/resources/settlements.js
@@ -85,13 +85,13 @@ module.exports = function (api) {
         }
 
         if(param.hasOwnProperty("expand[]")) {
-          expand = { "expand[]" : param["expand[]"] }
+          expand = param["expand[]"]
         }
   
         return api.get({
           url: `${BASE_URL}/ondemand/${settlementId}`,
           data: {
-            expand
+            "expand[]": expand
           }
         }, callback);
       },
@@ -111,7 +111,7 @@ module.exports = function (api) {
             url = `${BASE_URL}/ondemand`;
         
         if(params.hasOwnProperty("expand[]")) {
-          expand = { "expand[]" : params["expand[]"] }
+          expand = params["expand[]"]
         }
 
         return api.get({
@@ -122,7 +122,7 @@ module.exports = function (api) {
             to,
             count,
             skip,
-            expand
+            "expand[]": expand
           }
         }, callback);
       },

--- a/lib/types/orders.d.ts
+++ b/lib/types/orders.d.ts
@@ -201,6 +201,14 @@ export declare namespace Orders {
         'expand[]'?: 'payments' | 'payments.card' | 'transfers' | 'virtual_account';
     }
 
+    interface ExpandDetails {
+        /**
+         * Used to retrieve additional information about the order.
+         * Using this parameter will cause a sub-entity to be added to the response.
+         */
+        'expand[]'?: 'payments' | 'payments.card' | 'transfers' | 'virtual_account';
+    }
+
     interface RazorpayBankAccountBaseRequestBody {
         /**
          * Name of the beneficiary.
@@ -451,8 +459,9 @@ declare function orders(api: any): {
     * @param orderId - The unique identifier of the order 
     *
     */
-    fetch(orderId: string): Promise<Orders.RazorpayOrder>
+    fetch(orderId: string, params?: Orders.ExpandDetails): Promise<Orders.RazorpayOrder>
     fetch(orderId: string, callback: (err: INormalizeError | null, data: Orders.RazorpayOrder) => void): void
+    fetch(orderId: string, params: Orders.ExpandDetails, callback: (err: INormalizeError | null, data: Orders.RazorpayOrder) => void): void
     /**
     * Edit a order given Order ID
     *

--- a/test/resources/orders.spec.js
+++ b/test/resources/orders.spec.js
@@ -28,6 +28,20 @@ describe('ORDERS', () => {
       })
     })
 
+    it('Passes expand[] as a query param', (done) => {
+      mocker.mock({
+        url: '/orders'
+      })
+
+      rzpInstance.orders.all({ 'expand[]': 'payments' }).then((response) => {
+        assert.ok(equal(
+          response.__JUST_FOR_TESTS__.requestQueryParams,
+          { skip: 0, count: 10, 'expand[]': 'payments' }
+        ), 'expand[] is sent as expand[]=payments alongside the defaults')
+        done()
+      })
+    })
+
     it('`From` & `To` date are converted to ms', (done) => {
       let fromDate = 'Aug 25, 2016'
       let toDate = 'Aug 30, 2016'
@@ -86,6 +100,61 @@ describe('ORDERS', () => {
       })
 
       rzpInstance.orders.fetch(orderId).then((response) => {
+        assert.equal(
+          response.__JUST_FOR_TESTS__.url,
+          `/v1/orders/${orderId}`,
+          'Fetch order url formed correctly'
+        )
+        done()
+      })
+    })
+
+    it('Passes expand[] as a query param', (done) => {
+      let orderId = 'order_sometestId'
+
+      mocker.mock({
+        url: `/orders/${orderId}`
+      })
+
+      rzpInstance.orders.fetch(orderId, { 'expand[]': 'payments' }).then((response) => {
+        assert.ok(equal(
+          response.__JUST_FOR_TESTS__.requestQueryParams,
+          { 'expand[]': 'payments' }
+        ), 'expand[] is sent as expand[]=payments')
+        assert.equal(
+          response.__JUST_FOR_TESTS__.url,
+          `/v1/orders/${orderId}?expand%5B%5D=payments`,
+          'expand[] is appended to the fetch url'
+        )
+        done()
+      })
+    })
+
+    it('Passes multiple expand[] values', (done) => {
+      let orderId = 'order_sometestId'
+
+      mocker.mock({
+        url: `/orders/${orderId}`
+      })
+
+      rzpInstance.orders.fetch(orderId, { 'expand[]': ['payments', 'transfers'] }).then((response) => {
+        assert.ok(equal(
+          response.__JUST_FOR_TESTS__.requestQueryParams,
+          { 'expand[]': ['payments', 'transfers'] }
+        ), 'each expand[] value is sent as its own expand[] param')
+        done()
+      })
+    })
+
+    it('Still accepts a callback as the second argument', (done) => {
+      let orderId = 'order_sometestId'
+
+      mocker.mock({
+        url: `/orders/${orderId}`
+      })
+
+      rzpInstance.orders.fetch(orderId, (err, response) => {
+        assert.equal(err, null, 'No error is returned')
         assert.equal(
           response.__JUST_FOR_TESTS__.url,
           `/v1/orders/${orderId}`,

--- a/test/resources/payments.spec.js
+++ b/test/resources/payments.spec.js
@@ -97,6 +97,22 @@ describe('PAYMENTS', () => {
         done()
       })
     })
+
+    it('Passes expand[] as a query param', (done) => {
+      let paymentId = 'pay_sometestId'
+
+      mocker.mock({
+        url: `/payments/${paymentId}`
+      })
+
+      rzpInstance.payments.fetch(paymentId, { 'expand[]': 'card' }).then((response) => {
+        assert.ok(equal(
+          response.__JUST_FOR_TESTS__.requestQueryParams,
+          { 'expand[]': 'card' }
+        ), 'expand[] is sent as expand[]=card')
+        done()
+      })
+    })
   })
 
   describe('Fetch Transfer', () => {


### PR DESCRIPTION
Closes #332.

`instance.orders.fetch(orderId)` had no way to pass `expand[]`, even though the HTTP API accepts it on that endpoint and `orders.all()` already exposes it. This adds an optional `params` argument, mirroring `payments.fetch(paymentId, params)`:

```js
instance.orders.fetch(orderId, { "expand[]": "payments" })
```

A callback is still accepted as the second argument, so existing `orders.fetch(orderId, cb)` callers are unaffected.

**A serialisation bug this uncovered**

Every existing `expand[]` site (`orders.all`, `payments.all`, `payments.fetch`, and both on-demand settlement calls) built the query as `{ expand: { "expand[]": value } }`. With the axios version this package depends on (`^1.18.1`) that serialises to:

```
?expand[expand][0]=payments
```

which the API does not recognise. Sending the value under the flat `"expand[]"` key produces what the API reference documents, including one `expand[]=` per value when an array is passed:

```
?expand[]=payments
?expand[]=payments&expand[]=transfers
```

All five sites now use the flat key. Verified with a nock intercept on the built package: `/v1/orders/order_x?expand%5B%5D=payments`.

**Tests**

New cases in `test/resources/orders.spec.js` and `test/resources/payments.spec.js` assert the parsed query params and the formed URL for `fetch` and `all`, multiple `expand[]` values, and the callback-as-second-argument path. Full suite: 384 passing.

**Also**

- `documents/order.md` documents the new parameter with an example.
- `lib/types/orders.d.ts` gains `Orders.ExpandDetails` and the matching `fetch` overloads.
- `dist/` is not included; it is rebuilt by `npm test`.

| Test Case Document URL                        |
|-----------------------------------------------|
| N/A, external contribution. Tests are in the PR: `test/resources/orders.spec.js`, `test/resources/payments.spec.js`. |
